### PR TITLE
Refactor GetQueryResultsResponse to extend QueryResponse.

### DIFF
--- a/Bigquery/GetQueryResultsResponse.php
+++ b/Bigquery/GetQueryResultsResponse.php
@@ -15,41 +15,10 @@
  * the License.
  */
 
-class Google_Service_Bigquery_GetQueryResultsResponse extends Google_Collection
+class Google_Service_Bigquery_GetQueryResultsResponse extends Google_Service_Bigquery_QueryResponse
 {
-  protected $collection_key = 'rows';
-  public $cacheHit;
-  protected $errorsType = 'Google_Service_Bigquery_ErrorProto';
-  protected $errorsDataType = 'array';
   public $etag;
-  public $jobComplete;
-  protected $jobReferenceType = 'Google_Service_Bigquery_JobReference';
-  protected $jobReferenceDataType = '';
-  public $kind;
-  public $pageToken;
-  protected $rowsType = 'Google_Service_Bigquery_TableRow';
-  protected $rowsDataType = 'array';
-  protected $schemaType = 'Google_Service_Bigquery_TableSchema';
-  protected $schemaDataType = '';
-  public $totalBytesProcessed;
-  public $totalRows;
 
-  public function setCacheHit($cacheHit)
-  {
-    $this->cacheHit = $cacheHit;
-  }
-  public function getCacheHit()
-  {
-    return $this->cacheHit;
-  }
-  public function setErrors($errors)
-  {
-    $this->errors = $errors;
-  }
-  public function getErrors()
-  {
-    return $this->errors;
-  }
   public function setEtag($etag)
   {
     $this->etag = $etag;
@@ -57,69 +26,5 @@ class Google_Service_Bigquery_GetQueryResultsResponse extends Google_Collection
   public function getEtag()
   {
     return $this->etag;
-  }
-  public function setJobComplete($jobComplete)
-  {
-    $this->jobComplete = $jobComplete;
-  }
-  public function getJobComplete()
-  {
-    return $this->jobComplete;
-  }
-  public function setJobReference(Google_Service_Bigquery_JobReference $jobReference)
-  {
-    $this->jobReference = $jobReference;
-  }
-  public function getJobReference()
-  {
-    return $this->jobReference;
-  }
-  public function setKind($kind)
-  {
-    $this->kind = $kind;
-  }
-  public function getKind()
-  {
-    return $this->kind;
-  }
-  public function setPageToken($pageToken)
-  {
-    $this->pageToken = $pageToken;
-  }
-  public function getPageToken()
-  {
-    return $this->pageToken;
-  }
-  public function setRows($rows)
-  {
-    $this->rows = $rows;
-  }
-  public function getRows()
-  {
-    return $this->rows;
-  }
-  public function setSchema(Google_Service_Bigquery_TableSchema $schema)
-  {
-    $this->schema = $schema;
-  }
-  public function getSchema()
-  {
-    return $this->schema;
-  }
-  public function setTotalBytesProcessed($totalBytesProcessed)
-  {
-    $this->totalBytesProcessed = $totalBytesProcessed;
-  }
-  public function getTotalBytesProcessed()
-  {
-    return $this->totalBytesProcessed;
-  }
-  public function setTotalRows($totalRows)
-  {
-    $this->totalRows = $totalRows;
-  }
-  public function getTotalRows()
-  {
-    return $this->totalRows;
   }
 }


### PR DESCRIPTION
The only difference between Google_Service_Bigquery_GetQueryResultsResponse and Google_Service_Bigquery_QueryResponse is the $etag property.

This refactoring reduces duplication, as well as helping promote extension by allowing both classes to be treated the same when it comes to working with the results.