### PR TITLE
Update MessagePartBody.php

### DIFF
--- a/Gmail/MessagePartBody.php
+++ b/Gmail/MessagePartBody.php
@@ -37,6 +37,17 @@ class Google_Service_Gmail_MessagePartBody extends Google_Model
   {
     return $this->data;
   }
+  //Decode base64 data in accordance with RFC 4648 section 4
+  public function decodeData()
+  {
+    return base64_decode(
+      str_replace(
+        array('-', '_'),
+        array('+', '/'),
+        $this->data
+      )
+    );
+  }
   public function setSize($size)
   {
     $this->size = $size;


### PR DESCRIPTION
I was experiencing corruption when decoding Message Part Body data. The new function 'decodeData()' will return a string that is safe to print and use. The function ensures that the string is compliant with RFC 4648 section 4 before passing it to the built in php function 'base64_decode()'.