### PR TITLE
Set alt parameter to json on Google_Service_Groupsettings_Resource_Groups::get

### DIFF
--- a/src/Google/Service/Groupssettings/Resource/Groups.php
+++ b/src/Google/Service/Groupssettings/Resource/Groups.php
@@ -34,7 +34,7 @@ class Google_Service_Groupssettings_Resource_Groups extends Google_Service_Resou
    */
   public function get($groupUniqueId, $optParams = array())
   {
-    $params = array('groupUniqueId' => $groupUniqueId);
+    $params = array('groupUniqueId' => $groupUniqueId, 'alt' => 'json');
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Groupssettings_Groups");
   }


### PR DESCRIPTION
The API is returning XML by default causing empty object response. This is fixed by using parameter alt=json.

https://github.com/google/google-api-php-client-services/issues/30
