### PR TITLE
Update TranslationsListResponse.php

### DIFF
--- a/src/Google/Service/Translate/TranslationsListResponse.php
+++ b/src/Google/Service/Translate/TranslationsListResponse.php
@@ -23,10 +23,10 @@ class Google_Service_Translate_TranslationsListResponse extends Google_Collectio
 
   public function setTranslations($translations)
   {
-    $this->translations = $translations;
+    $this->data['translations'] = $translations;
   }
   public function getTranslations()
   {
-    return $this->translations;
+    return $this->data['translations'];
   }
 }


### PR DESCRIPTION
This way accessing the array generated by `$service->translations->listTranslations($q, $target, $optParams = array())` does not return `empty`, but the correct translation.