### PR TITLE
Update deprecated parameter for People service

### DIFF
--- a/src/Google/Service/People.php
+++ b/src/Google/Service/People.php
@@ -89,7 +89,7 @@ class Google_Service_People extends Google_Service
                   'type' => 'string',
                   'required' => true,
                 ),
-                'requestMask.includeField' => array(
+                'personFields' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -98,7 +98,7 @@ class Google_Service_People extends Google_Service
               'path' => 'v1/people:batchGet',
               'httpMethod' => 'GET',
               'parameters' => array(
-                'requestMask.includeField' => array(
+                'personFields' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -143,7 +143,7 @@ class Google_Service_People extends Google_Service
                   'location' => 'query',
                   'type' => 'integer',
                 ),
-                'requestMask.includeField' => array(
+                'personFields' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),


### PR DESCRIPTION
The 'requestMask.includeField' parameter in the People service calls has been deprecated and renamed to personFields.

Documentation: https://developers.google.com/people/api/rest/v1/people.connections/list

This is referenced in #67.