### PR TITLE
enforce code standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ install:
 
 script:
   - phpunit
+  - phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
 
 script:
   - phpunit
-  - phpcs
+  - vendor/squizlabs/php_codesniffer/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~4.8",
+        "squizlabs/php_codesniffer": "*"
     },
     "autoload": {
         "psr-0": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+ <description>The coding standard for PHP_CodeSniffer itself.</description>
+
+ <file>src</file>
+ <file>tests</file>
+
+ <exclude-pattern>*/Standards/*/Tests/*.(inc|css|js)</exclude-pattern>
+
+ <arg name="basepath" value="."/>
+ <arg name="colors" />
+ <arg name="parallel" value="75" />
+ <arg value="np"/>
+
+ <!-- Don't hide tokenizer exceptions -->
+ <rule ref="Internal.Tokenizer.Exception">
+  <type>error</type>
+ </rule>
+
+ <!-- Include the whole PSR1 standard -->
+ <rule ref="PSR1">
+    <exclude name="Squiz.Classes.ValidClassName" />
+    <exclude name="PSR1.Classes.ClassDeclaration" />
+ </rule>
+
+ <!-- Include the whole PSR2 standard -->
+ <rule ref="PSR2">
+ </rule>
+
+ <rule ref="Generic.WhiteSpace.ScopeIndent">
+  <properties>
+   <property name="indent" type="number" value="2"/>
+  </properties>
+ </rule>
+</ruleset>

--- a/src/Google/Service/CloudFunctions.php
+++ b/src/Google/Service/CloudFunctions.php
@@ -47,6 +47,5 @@ class Google_Service_CloudFunctions extends Google_Service
     $this->servicePath = '';
     $this->version = 'v1';
     $this->serviceName = 'cloudfunctions';
-
   }
 }

--- a/src/Google/Service/TagManager/Resource/AccountsContainersVersions.php
+++ b/src/Google/Service/TagManager/Resource/AccountsContainersVersions.php
@@ -95,8 +95,10 @@ class Google_Service_TagManager_Resource_AccountsContainersVersions extends Goog
    * @param array $optParams Optional parameters.
    * @return Google_Service_TagManager_ContainerVersion
    */
+  // @codingStandardsIgnoreStart
   public function set_latest($path, $optParams = array())
   {
+    // @codingStandardsIgnoreEnd
     $params = array('path' => $path);
     $params = array_merge($params, $optParams);
     return $this->call('set_latest', array($params), "Google_Service_TagManager_ContainerVersion");

--- a/src/Google/Service/TagManager/Resource/AccountsContainersWorkspaces.php
+++ b/src/Google/Service/TagManager/Resource/AccountsContainersWorkspaces.php
@@ -51,8 +51,10 @@ class Google_Service_TagManager_Resource_AccountsContainersWorkspaces extends Go
    * @param array $optParams Optional parameters.
    * @return Google_Service_TagManager_CreateContainerVersionResponse
    */
+  // @codingStandardsIgnoreStart
   public function create_version($path, Google_Service_TagManager_CreateContainerVersionRequestVersionOptions $postBody, $optParams = array())
   {
+    // @codingStandardsIgnoreEnd
     $params = array('path' => $path, 'postBody' => $postBody);
     $params = array_merge($params, $optParams);
     return $this->call('create_version', array($params), "Google_Service_TagManager_CreateContainerVersionResponse");
@@ -140,8 +142,10 @@ class Google_Service_TagManager_Resource_AccountsContainersWorkspaces extends Go
    * @param array $optParams Optional parameters.
    * @return Google_Service_TagManager_QuickPreviewResponse
    */
+  // @codingStandardsIgnoreStart
   public function quick_preview($path, $optParams = array())
   {
+    // @codingStandardsIgnoreEnd
     $params = array('path' => $path);
     $params = array_merge($params, $optParams);
     return $this->call('quick_preview', array($params), "Google_Service_TagManager_QuickPreviewResponse");
@@ -158,8 +162,10 @@ class Google_Service_TagManager_Resource_AccountsContainersWorkspaces extends Go
    * @opt_param string fingerprint When provided, this fingerprint must match the
    * fingerprint of the entity_in_workspace in the merge conflict.
    */
+  // @codingStandardsIgnoreStart
   public function resolve_conflict($path, Google_Service_TagManager_Entity $postBody, $optParams = array())
   {
+    // @codingStandardsIgnoreEnd
     $params = array('path' => $path, 'postBody' => $postBody);
     $params = array_merge($params, $optParams);
     return $this->call('resolve_conflict', array($params));

--- a/src/Google/Service/TagManager/Resource/AccountsContainersWorkspacesFolders.php
+++ b/src/Google/Service/TagManager/Resource/AccountsContainersWorkspacesFolders.php
@@ -114,8 +114,10 @@ class Google_Service_TagManager_Resource_AccountsContainersWorkspacesFolders ext
    * @opt_param string triggerId The triggers to be moved to the folder.
    * @opt_param string variableId The variables to be moved to the folder.
    */
+  // @codingStandardsIgnoreStart
   public function move_entities_to_folder($path, Google_Service_TagManager_Folder $postBody, $optParams = array())
   {
+    // @codingStandardsIgnoreEnd
     $params = array('path' => $path, 'postBody' => $postBody);
     $params = array_merge($params, $optParams);
     return $this->call('move_entities_to_folder', array($params));


### PR DESCRIPTION
For issue #78, this change uses phpcs to enforce code standards. I used [PSR-1](http://www.php-fig.org/psr/psr-1/) and [PSR-2](http://www.php-fig.org/psr/psr-2/), but needed to make a few exceptions to get it to pass with the current code. 