### PR TITLE
Missing personFields parameter

### DIFF
--- a/src/Google/Service/People.php
+++ b/src/Google/Service/People.php
@@ -151,6 +151,10 @@ class Google_Service_People extends Google_Service
                   'location' => 'query',
                   'type' => 'string',
                 ),
+                'personFields' => array(
+                  'location' => 'query',
+                  'type' => 'string',
+                ),
               ),
             ),
           )


### PR DESCRIPTION
Hello,
I am trying to execute this:

```php
        $client = new \Google_Client();
        $client->setAccessToken($acess_token);
        $people_service = new \Google_Service_People($client);
        $optParams = array(
            'pageSize' => 10,
            'personFields'=>'emailAddresses'
        );
        $results = $people_service->people_connections->listPeopleConnections('people/me', $optParams);
```
And i got the error:

**Google_Exception in Resource.php line 147:
(list) unknown parameter: 'personFields'**

Adding the parameter `personFields` in the Google_Service People class constructor has resolved the problem.