### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - composer install
 
 script:
-  - phpunit
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~4.8.36"
     },
     "autoload": {
         "psr-0": {

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -18,7 +18,9 @@
  * under the License.
  */
 
-class Google_Service_ServiceTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Google_Service_ServiceTest extends TestCase
 {
   public function setUp()
   {


### PR DESCRIPTION
Simplify version of #90.

I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.

Also, changed `Travis CI` to run the` PHPUnit` version installed with `Composer`, not the globally one. The global one is in version `~6.4`, and contains some deprecated method that we'll need to work on that latter.