### PR TITLE
Add PHP 7.2 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 install:
   - composer install


### PR DESCRIPTION
So tests will run on PHP 7.2 as well.