### PR TITLE
Clean response from google translate

### DIFF
--- a/src/Google/Service/Translate/TranslationsListResponse.php
+++ b/src/Google/Service/Translate/TranslationsListResponse.php
@@ -35,4 +35,14 @@ class Google_Service_Translate_TranslationsListResponse extends Google_Collectio
   {
     return $this->translations;
   }
+  /**
+   * @param array $array
+  */
+  protected function mapTypes($array)
+  {
+    if (isset($array['data'])) {
+      $array = $array['data'];
+    }
+    parent::mapTypes($array);
+  }
 }


### PR DESCRIPTION
Dear Sir or Madame,

I just started develop with the google client api. I try to translate text with the google translation api.
But the response of the service is always empty. After a little debugging I've found out that the response from google has an array with the following structure: data => [translations => [...]]. The standard expects an array with the following structure translations => [...].
So I've extended the response class and remove the data level.

Best regards
Markus