### PR TITLE
Fix broken Composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Google_Service_": "src"
+            "Google_Service_": "src/Google/Service"
         }
     }
 }


### PR DESCRIPTION
I just tried to use this client library and found that calling `new \Google_Service_YouTube($client)` gave me an exception because the class could not be found. I use Composer autoloading exclusively for my entire project, so I figured it was something with this library that prevented it from being autoloaded properly. Making this change let me use the library normally, so I'm submitting this in the hopes that this would fix the issue for everyone who decides to use this package.