### PR TITLE
Fix PeopleConnections comment code

### DIFF
--- a/src/Google/Service/People/Resource/PeopleConnections.php
+++ b/src/Google/Service/People/Resource/PeopleConnections.php
@@ -20,7 +20,7 @@
  * Typical usage is:
  *  <code>
  *   $peopleService = new Google_Service_People(...);
- *   $connections = $peopleService->connections;
+ *   $connections = $peopleService->people_connections;
  *  </code>
  */
 class Google_Service_People_Resource_PeopleConnections extends Google_Service_Resource

--- a/src/Google/Service/PeopleService/Resource/PeopleConnections.php
+++ b/src/Google/Service/PeopleService/Resource/PeopleConnections.php
@@ -20,7 +20,7 @@
  * Typical usage is:
  *  <code>
  *   $peopleService = new Google_Service_PeopleService(...);
- *   $connections = $peopleService->connections;
+ *   $connections = $peopleService->people_connections;
  *  </code>
  */
 class Google_Service_PeopleService_Resource_PeopleConnections extends Google_Service_Resource


### PR DESCRIPTION
Wrong property `connections` fix to `people_connections`:

```
<code>
 $peopleService = new Google_Service_People(...);
 $connections = $peopleService->people_connections;
</code>
```